### PR TITLE
ar: pass minio secrets from django to the ARC

### DIFF
--- a/apps/augmentedreality/templatetags/react_augmentedreality.py
+++ b/apps/augmentedreality/templatetags/react_augmentedreality.py
@@ -1,6 +1,7 @@
 import json
 
 from django import template
+from django.conf import settings
 from django.utils.html import format_html
 
 from apps.augmentedreality.serializers import SceneSerializer
@@ -18,6 +19,9 @@ def react_augmentedreality_arc(topic):
 
     if topic.scene:
         attributes["scene"] = SceneSerializer(topic.scene).data
+
+    if hasattr(settings, "MINIO_DATA"):
+        attributes["minioData"] = settings.MINIO_DATA
 
     return format_html(
         '<div data-arpas-widget="arc" ' 'data-attributes="{attributes}"></div>',

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@react-three/fiber": "^8",
         "@react-three/xr": "^6",
         "adhocracy4": "git+https://github.com/liqd/adhocracy4#82fb1ef56b03d51b8bb9d1b2edddcb5f75a96344",
-        "arpas-arc": "git+https://github.com/liqd/arpas-arc#3bb0b399066c323b53128bc9ae86e16a2170828d",
+        "arpas-arc": "git+https://github.com/liqd/arpas-arc#df326f735d0093e062af31c7c0cb0f5dd31324bf",
         "autoprefixer": "10.4.20",
         "bootstrap": "5.2.3",
         "css-loader": "7.1.2",
@@ -53,7 +53,7 @@
         "terser-webpack-plugin": "5.3.11",
         "three": "^0.175.0",
         "timeago.js": "4.0.2",
-        "zustand": "^4.4.7"
+        "zustand": "^4.5.7"
       },
       "devDependencies": {
         "@babel/core": "7.26.0",
@@ -8097,8 +8097,8 @@
     },
     "node_modules/arpas-arc": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/liqd/arpas-arc.git#3bb0b399066c323b53128bc9ae86e16a2170828d",
-      "integrity": "sha512-5SrWAnzrQ6MpsXpKcWudFPjggvLftI9TULdanRq+9yy6O/X1kGsqbnIIrX3rYVFvDPHmEg6ZliM8MiT9XeuZqg==",
+      "resolved": "git+ssh://git@github.com/liqd/arpas-arc.git#df326f735d0093e062af31c7c0cb0f5dd31324bf",
+      "integrity": "sha512-1O2G0ST3tHmii46fHXfk/98EiXAQuFpZgst4eRALUaMQEBcY0Rg7TmXeZ5T7JJthr97iMiPQgUTxyWTE2L3qfQ==",
       "dependencies": {
         "web-vitals": "^2.1.4"
       },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@react-three/fiber": "^8",
     "@react-three/xr": "^6",
     "adhocracy4": "git+https://github.com/liqd/adhocracy4#82fb1ef56b03d51b8bb9d1b2edddcb5f75a96344",
-    "arpas-arc": "git+https://github.com/liqd/arpas-arc#3bb0b399066c323b53128bc9ae86e16a2170828d",
+    "arpas-arc": "git+https://github.com/liqd/arpas-arc#df326f735d0093e062af31c7c0cb0f5dd31324bf",
     "autoprefixer": "10.4.20",
     "bootstrap": "5.2.3",
     "css-loader": "7.1.2",
@@ -59,7 +59,7 @@
     "terser-webpack-plugin": "5.3.11",
     "three": "^0.175.0",
     "timeago.js": "4.0.2",
-    "zustand": "^4.4.7"
+    "zustand": "^4.5.7"
   },
   "devDependencies": {
     "@babel/core": "7.26.0",


### PR DESCRIPTION
This expects  a `local.py` in `adhocracy-plus/config/settings/` with contents like 

```py
MINIO_DATA = {
    "endpoint": "https://localhost",
    "region": "some-region",
    "accessKey": "accessKey",
    "secretKey": "secretKey"
}
```

Also updates ARC  dependency.